### PR TITLE
Add DevApps podcast episode 119 - Roadmap GitHub Copilot

### DIFF
--- a/content/2.speaking.yml
+++ b/content/2.speaking.yml
@@ -9,7 +9,7 @@ events:
     date: 2026-03-31
     event: DevApps
     type: podcast
-    format: talk
+    format: panel
     location: Online
     url: https://devapps.ms/podcasts/119-github-copilot-roadmap
   - name: "Roundtable: Aspire13, DevOps Server, WinUI3, CsWin32"

--- a/content/2.speaking.yml
+++ b/content/2.speaking.yml
@@ -5,6 +5,13 @@ seo:
   title: Speaking - Alexandre Nédélec
   description: Discover my talks and presentations at conferences about Cloud, DevOps, Pulumi, and .NET development.
 events:
+  - name: "Roadmap GitHub Copilot"
+    date: 2026-03-31
+    event: DevApps
+    type: podcast
+    format: talk
+    location: Online
+    url: https://devapps.ms/podcasts/119-github-copilot-roadmap
   - name: "Roundtable: Aspire13, DevOps Server, WinUI3, CsWin32"
     date: 2025-12-10
     event: devdevdev.net


### PR DESCRIPTION
Adds a new speaking entry for the DevApps podcast episode 119, where Alexandre talked about the GitHub Copilot roadmap.

- **Event:** DevApps
- **Date:** 2026-03-31
- **Type:** podcast / **Format:** panel
- **URL:** https://devapps.ms/podcasts/119-github-copilot-roadmap